### PR TITLE
Remove duplicate in invoice `kind`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1172,7 +1172,6 @@ Pole: `kind`
 	"advance" - faktura zaliczkowa
 	"final" - faktura końcowa
 	"correction" - faktura korekta
-	"vat_mp" - faktura MP
 	"invoice_other" - inna faktura
 	"vat_margin" - faktura marża
 	"kp" - kasa przyjmie


### PR DESCRIPTION
Usunięcie duplikatu występującego w polu `kind` faktury. Wartość `vat_mp` została już udokumentowana poniżej, przy polu `vat_rr`. 