### PR TITLE
KSeF: aktualizacja ograniczeń długości dla uwag (descriptions)

### DIFF
--- a/KSeF.md
+++ b/KSeF.md
@@ -279,7 +279,8 @@ KSeF narzuca limity na długość niektórych pól:
 | Pole | Maksymalna długość | Nowe ograniczenie |
 |------|-------------------|------------|
 | Nazwa pozycji (`positions[].name`) | 256 znaków | Tak |
-| Opis/stopka faktury (`description`) | 3500 znaków | Tak |
+| Rodzaj uwagi (`descriptions[].kind`) | 256 znaków | Tak |
+| Treść uwagi (`descriptions[].content`) | 256 znaków | Tak |
 | Email (`buyer_email`, `seller_email`) | 255 znaków | Tak (format) |
 | Telefon (`buyer_phone`, `seller_phone`) | 16 znaków | Tak |
 | Powód korekty (`correction_reason`) na korekcie| 256 znaków | Tak |
@@ -288,7 +289,9 @@ KSeF narzuca limity na długość niektórych pól:
 | GTIN (pole `additional_info` gdy `additional_info_desc=GTIN`) | 20 znaków | Tak |
 | PKWiU/PKOB/CN (pole `additional_info`) | 50 znaków | Tak |
 
-**Ważne:** Jeśli Twoja integracja generuje długie opisy pozycji lub stopki faktur, musisz je skrócić.
+**Ważne:** Jeśli Twoja integracja generuje długie opisy pozycji, musisz je skrócić.
+
+**Uwagi do faktury (`descriptions`):** Pola `kind` i `content` w nowym modelu uwag (zob. [Uwagi na fakturze](README.md#f25) w README) są ograniczone przez schemę KSeF do **256 znaków** każde — odpowiadają elementowi `DodatkowyOpis` (`Klucz` i `Wartość`). Stare pole `description` jest nadal akceptowane po API, ale przy wysyłce do KSeF zostaje automatycznie skonwertowane na pojedynczy wpis `descriptions` i w tym momencie zaczyna go obowiązywać ten sam limit 256 znaków. Dla kont bez aktywnego KSeF pole `descriptions[].content` dopuszcza dalej do 65535 znaków (limit Fakturowni).
 
 
 ### Typy faktur wysyłane do KSeF

--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,8 @@ curl https://YOUR_DOMAIN.fakturownia.pl/invoices/INVOICE_ID.json \
 - Jeśli nie podano wartości `kind`, zostanie ustawiona wartość domyślna `"Uwaga"`.
 - Maksymalna liczba uwag na jednej fakturze: **10 000**.
 
+> **KSeF:** Przy wysyłce do KSeF pole `content` jest dodatkowo ograniczone do **256 znaków** (wymóg schemy — element `DodatkowyOpis.Wartość`). Dla kont bez aktywnego KSeF limit pozostaje na poziomie 65535 znaków. Szczegóły i pełna lista ograniczeń długości pól KSeF: [KSeF.md — Ograniczenia długości pól](KSeF.md#ograniczenia-długości-pól).
+
 <a name="f26"></a>
 
 ## Rozliczenia na fakturze (settlement_positions)


### PR DESCRIPTION
## Summary

Aktualizacja dokumentacji API po zmianach z zadania [#25920](https://fakturownia.intum.com/organize/tasks/25920) (komentarze 68-77, w szczególności 71 i 76).

- **KSeF.md — sekcja "Ograniczenia długości pól":**
  - Usunięty wiersz `Opis/stopka faktury (description) 3500 znaków` — wprowadzał w błąd, bo stare pole `description` jest teraz automatycznie konwertowane na `descriptions` i przy wysyłce do KSeF wchodzi w limit 256 znaków.
  - Dodane wiersze dla `descriptions[].kind` i `descriptions[].content` (po 256 znaków — wymóg schemy KSeF, odpowiadają elementowi `DodatkowyOpis.Klucz` / `DodatkowyOpis.Wartość`).
  - Dodany akapit wyjaśniający konwersję starego pola `description` oraz że na kontach bez aktywnego KSeF `descriptions[].content` dalej dopuszcza do 65535 znaków.

- **README.md — sekcja f25 "Uwagi na fakturze":**
  - Krótka adnotacja pod blokiem "Walidacje" informująca, że przy wysyłce do KSeF `content` jest dodatkowo ograniczony do 256 znaków (z odnośnikiem do pełnej tabeli w `KSeF.md`).

## Rozważane alternatywy

### Wybrane rozwiązanie: zostawić w README.md `content: max 65535 znaków`, a limit 256 wskazać wyłącznie jako ograniczenie KSeF
Zgodnie z sugestią z komentarza 76 — na kontach bez aktywnego KSeF dłuższe opisy są nadal poprawnie zapisywane przez API. Limit 256 to wymóg schemy KSeF (`DodatkowyOpis.Wartość`), nie API. Adnotacja w README wprost informuje czytelnika o tej różnicy i linkuje do szczegółów w `KSeF.md`.

### Alternatywa A: zmienić limit `content` w README.md na 256 znaków
- Plusy: spójność z zachowaniem UI (formatka wymusza 256) i KSeF.
- Minusy: nieprawda dla kont bez KSeF — realny limit w bazie/modelu to dalej 65535. Integracje API na kontach bez KSeF mogłyby dostać niespójne komunikaty.
- Dlaczego odrzucone: komentarz 76 wprost prosi o pozostawienie 65535 w README.

### Alternatywa B: dopisać odnośnik do KSeF tylko w README, bez ruszania tabeli w KSeF.md
- Plusy: minimalna zmiana.
- Minusy: nie rozwiązuje problemu zgłoszonego w komentarzu 71 — wiersz `Opis/stopka faktury (description) 3500 znaków` w KSeF.md dalej wprowadzałby w błąd, a nowe pola `descriptions[].kind` / `descriptions[].content` nie byłyby udokumentowane w tabeli ograniczeń KSeF.
- Dlaczego odrzucone: nie domyka raportu z zadania.

## Test plan

- [x] `KSeF.md` — weryfikacja że tabela ograniczeń renderuje się poprawnie (nowe wiersze, brak starego wiersza `description 3500`).
- [x] `README.md` — weryfikacja że adnotacja KSeF renderuje się jako blockquote pod sekcją Walidacje (f25).
- [ ] Link `README.md#f25` z `KSeF.md` — sprawdzić w podglądzie GitHub, że skacze do właściwej sekcji.
- [ ] Link `KSeF.md#ograniczenia-długości-pól` z `README.md` — sprawdzić w podglądzie GitHub, że skacze do właściwej sekcji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)