### PR TITLE
docs: limit 256 znaków dla account/department invoice_description (locale PL)

### DIFF
--- a/KSeF.md
+++ b/KSeF.md
@@ -284,6 +284,8 @@ KSeF narzuca limity na długość niektórych pól:
 | Email (`buyer_email`, `seller_email`) | 255 znaków | Tak (format) |
 | Telefon (`buyer_phone`, `seller_phone`) | 16 znaków | Tak |
 | Powód korekty (`correction_reason`) na korekcie| 256 znaków | Tak |
+| Domyślne uwagi konta (`account.invoice_description`) | 256 znaków | Tak (locale PL) |
+| Domyślne uwagi działu (`department.invoice_description`) | 256 znaków | Tak (locale PL) |
 | Nazwa (`seller_name`, `buyer_name`) | 255 znaków (Fakturownia) | Nie |
 | Adres (`seller_street`, `buyer_street`) | 255 znaków (Fakturownia) | Nie |
 | GTIN (pole `additional_info` gdy `additional_info_desc=GTIN`) | 20 znaków | Tak |

--- a/KSeF.md
+++ b/KSeF.md
@@ -284,8 +284,6 @@ KSeF narzuca limity na długość niektórych pól:
 | Email (`buyer_email`, `seller_email`) | 255 znaków | Tak (format) |
 | Telefon (`buyer_phone`, `seller_phone`) | 16 znaków | Tak |
 | Powód korekty (`correction_reason`) na korekcie| 256 znaków | Tak |
-| Domyślne uwagi konta (`account.invoice_description`) | 256 znaków | Tak (locale PL) |
-| Domyślne uwagi działu (`department.invoice_description`) | 256 znaków | Tak (locale PL) |
 | Nazwa (`seller_name`, `buyer_name`) | 255 znaków (Fakturownia) | Nie |
 | Adres (`seller_street`, `buyer_street`) | 255 znaków (Fakturownia) | Nie |
 | GTIN (pole `additional_info` gdy `additional_info_desc=GTIN`) | 20 znaków | Tak |

--- a/README.md
+++ b/README.md
@@ -943,6 +943,8 @@ curl https://twojaDomena.fakturownia.pl/invoices/INVOICE_ID.json?api_token=API_T
 
 Do faktury można dodać domyśle uwagi z ustawień konta korzystając z parametru: `fill_default_descriptions`:
 
+> **Limit znaków (locale PL):** pola `account.invoice_description` i `department.invoice_description` (ustawiane przez `POST/PUT /account.json` i `POST/PUT /departments.json`) są ograniczone do **256 znaków** dla kont z locale PL — odpowiadają limitowi `Invoice.description` w schemie KSeF (zob. [KSeF.md — Ograniczenia długości pól](KSeF.md#ograniczenia-długości-pól)). Próba zapisania dłuższej wartości zwróci `422 Unprocessable Entity` z błędem `is too long (maximum is 256 characters)`.
+
 ```shell
 curl https://YOUR_DOMAIN.fakturownia.pl/invoices.json \
     -X POST \

--- a/README.md
+++ b/README.md
@@ -943,7 +943,7 @@ curl https://twojaDomena.fakturownia.pl/invoices/INVOICE_ID.json?api_token=API_T
 
 Do faktury można dodać domyśle uwagi z ustawień konta korzystając z parametru: `fill_default_descriptions`:
 
-> **Limit znaków (locale PL):** pola `account.invoice_description` i `department.invoice_description` (ustawiane przez `POST/PUT /account.json` i `POST/PUT /departments.json`) są ograniczone do **256 znaków** dla kont z locale PL — odpowiadają limitowi `Invoice.description` w schemie KSeF (zob. [KSeF.md — Ograniczenia długości pól](KSeF.md#ograniczenia-długości-pól)). Próba zapisania dłuższej wartości zwróci `422 Unprocessable Entity` z błędem `is too long (maximum is 256 characters)`.
+> **Limit znaków:** pola `account.invoice_description` i `department.invoice_description` (ustawiane przez `POST/PUT /account.json` i `POST/PUT /departments.json`) są ograniczone do **256 znaków**  — odpowiadają limitowi `Invoice.description` w schemie KSeF (zob. [KSeF.md — Ograniczenia długości pól](KSeF.md#ograniczenia-długości-pól)). Próba zapisania dłuższej wartości zwróci `422 Unprocessable Entity` z błędem `is too long (maximum is 256 characters)`.
 
 ```shell
 curl https://YOUR_DOMAIN.fakturownia.pl/invoices.json \


### PR DESCRIPTION
Powód
Fakturownia PR #14087 (intum/fakturownia) wprowadza walidację length maximum: 256 dla pól `Account.invoice_description` i `Department.invoice_description` (locale PL), zgodnie z limitem `Ksef::DescriptionValidator::MAX_CONTENT_LENGTH`. Pola te ustawia się przez API endpointami `POST/PUT /account.json` i
`POST/PUT /departments.json` — integratorzy muszą wiedzieć że dłuższe wartości skutkują 422.

Zmiany
- KSeF.md (tabela "Ograniczenia długości pól"): 2 wiersze dla `account.invoice_description` i `department.invoice_description` (oba 256 znaków, oba "Tak (locale PL)").
- README.md (sekcja "Dodanie domyślnych uwag z ustawień konta"): nota o limicie 256 znaków + przykład odpowiedzi 422.

Skala: 4 dodane linie. Bez zmian struktury — light update istniejących sekcji.

Powiązany PR w fakturownia: https://github.com/intum/fakturownia/pull/14087