### PR TITLE
Dokumentacja: pole triangular_transaction (transakcja trójstronna, P_23)

### DIFF
--- a/KSeF.md
+++ b/KSeF.md
@@ -272,6 +272,41 @@ Przykład faktury ze stawką "np":
 }
 ```
 
+### Transakcja trójstronna uproszczona (`triangular_transaction`)
+
+Pole `triangular_transaction` (boolean) oznacza wewnątrzwspólnotową transakcję trójstronną w procedurze uproszczonej — fakturę wystawianą przez drugiego w kolejności podatnika (art. 135 ust. 1 pkt 4 lit. b i c oraz ust. 2 ustawy o VAT; art. 141 dyrektywy 2006/112/WE). W strukturze KSeF odpowiada polu **P_23** w sekcji adnotacji.
+
+**Warunki uznania pola:** faktura krajowa (konto z locale PL), przychodowa, typu `vat` (lub korekta faktury VAT), oznaczona jako odwrotne obciążenie (`"reverse_charge": true`). Bez `"reverse_charge": true` pole jest ignorowane (ustawiane na `false`) — samo `triangular_transaction: true` nie włącza odwrotnego obciążenia.
+
+**Ustawiane automatycznie (nie trzeba ich przesyłać):** gdy pole zostanie uznane, system sam:
+- wymusza na wszystkich pozycjach stawkę `"np"` (nadpisuje przesłaną wartość),
+- ustawia `"np_tax_kind": "export_service"`,
+- dodaje oznaczenie procedury `"TT_D"` do `procedure_designations`.
+
+Przykład faktury z transakcją trójstronną:
+```json
+{
+  "invoice": {
+    "kind": "vat",
+    "reverse_charge": true,
+    "triangular_transaction": true,
+    "seller_name": "Moja Firma Sp. z o.o.",
+    "seller_tax_no": "5252445767",
+    "buyer_name": "Foreign Company Ltd",
+    "buyer_tax_no": "DE123456789",
+    "buyer_country": "DE",
+    "buyer_company": true,
+    "positions": [
+      {
+        "name": "Dostawa towarów w procedurze trójstronnej",
+        "quantity": 1,
+        "total_price_gross": 5000.00
+      }
+    ]
+  }
+}
+```
+
 ### Ograniczenia długości pól
 
 KSeF narzuca limity na długość niektórych pól:

--- a/README.md
+++ b/README.md
@@ -1530,6 +1530,7 @@ Pola faktury
 "exempt_tax_kind": "", Podstawa zwolnienia z podatku VAT (stosowana, gdy pozycja ma tax="zw", wcześniej należy również włączyć opcję "Wybór podstawy zastosowania stawki zw (zwolnione z opodatkowania) na fakturze" w ustawieniach konta)
 "np_tax_kind": "", Podstawa zastosowania stawki NP (nie podlega) na fakturze
 "reverse_charge": false, Odwrotne obciążenie. Oznaczenie faktury jako 'Odwrotne obciążenie' spowoduje wymuszenie na pozycjach (positions) odpowiedniej stawki podatku (tax) w zależności od kraju nabywcy (buyer_country): 'oo' dla 'PL' lub 'np' w pozostałych przypadkach
+"triangular_transaction": false, - Wewnątrzwspólnotowa transakcja trójstronna uproszczona (faktura wystawiana przez drugiego w kolejności podatnika, art. 141 dyrektywy 2006/112/WE). Wymaga oznaczenia faktury jako 'Odwrotne obciążenie' ("reverse_charge": true) oraz faktury krajowej (locale PL) typu 'vat' (lub korekty faktury VAT). Ustawienie na 'true' automatycznie wymusza na pozycjach (positions) stawkę "np", ustawia "np_tax_kind": "export_service" oraz dodaje oznaczenie procedury "TT_D" do "procedure_designations". Odpowiada polu P_23 w strukturze KSeF / JPK_FA.
 "corrected_content_before": "", Treść korygowana (pole ma zastosowanie dla faktur korygujących)
 "corrected_content_after": "", Treść prawidłowa (pole ma zastosowanie dla faktur korygujących)
 "accounting_note_kind": "credit" lub "debit", w zależności, czy Nota księgowa jest obciążąjąca czy uznaniowa (pole ma zastosowanie tylko dla not księgowych)

--- a/README.md
+++ b/README.md
@@ -1530,7 +1530,6 @@ Pola faktury
 "exempt_tax_kind": "", Podstawa zwolnienia z podatku VAT (stosowana, gdy pozycja ma tax="zw", wcześniej należy również włączyć opcję "Wybór podstawy zastosowania stawki zw (zwolnione z opodatkowania) na fakturze" w ustawieniach konta)
 "np_tax_kind": "", Podstawa zastosowania stawki NP (nie podlega) na fakturze
 "reverse_charge": false, Odwrotne obciążenie. Oznaczenie faktury jako 'Odwrotne obciążenie' spowoduje wymuszenie na pozycjach (positions) odpowiedniej stawki podatku (tax) w zależności od kraju nabywcy (buyer_country): 'oo' dla 'PL' lub 'np' w pozostałych przypadkach
-"triangular_transaction": false, - Wewnątrzwspólnotowa transakcja trójstronna uproszczona (faktura wystawiana przez drugiego w kolejności podatnika, art. 141 dyrektywy 2006/112/WE). Wymaga oznaczenia faktury jako 'Odwrotne obciążenie' ("reverse_charge": true) oraz faktury krajowej (locale PL) typu 'vat' (lub korekty faktury VAT). Ustawienie na 'true' automatycznie wymusza na pozycjach (positions) stawkę "np", ustawia "np_tax_kind": "export_service" oraz dodaje oznaczenie procedury "TT_D" do "procedure_designations". Odpowiada polu P_23 w strukturze KSeF / JPK_FA.
 "corrected_content_before": "", Treść korygowana (pole ma zastosowanie dla faktur korygujących)
 "corrected_content_after": "", Treść prawidłowa (pole ma zastosowanie dla faktur korygujących)
 "accounting_note_kind": "credit" lub "debit", w zależności, czy Nota księgowa jest obciążąjąca czy uznaniowa (pole ma zastosowanie tylko dla not księgowych)

--- a/README.md
+++ b/README.md
@@ -1530,6 +1530,7 @@ Pola faktury
 "exempt_tax_kind": "", Podstawa zwolnienia z podatku VAT (stosowana, gdy pozycja ma tax="zw", wcześniej należy również włączyć opcję "Wybór podstawy zastosowania stawki zw (zwolnione z opodatkowania) na fakturze" w ustawieniach konta)
 "np_tax_kind": "", Podstawa zastosowania stawki NP (nie podlega) na fakturze
 "reverse_charge": false, Odwrotne obciążenie. Oznaczenie faktury jako 'Odwrotne obciążenie' spowoduje wymuszenie na pozycjach (positions) odpowiedniej stawki podatku (tax) w zależności od kraju nabywcy (buyer_country): 'oo' dla 'PL' lub 'np' w pozostałych przypadkach
+"triangular_transaction": false, Wewnątrzwspólnotowa transakcja trójstronna uproszczona (pole P_23 w KSeF; więcej informacji w KSeF.md)
 "corrected_content_before": "", Treść korygowana (pole ma zastosowanie dla faktur korygujących)
 "corrected_content_after": "", Treść prawidłowa (pole ma zastosowanie dla faktur korygujących)
 "accounting_note_kind": "credit" lub "debit", w zależności, czy Nota księgowa jest obciążąjąca czy uznaniowa (pole ma zastosowanie tylko dla not księgowych)


### PR DESCRIPTION
## Cel

Dokumentacja pola `triangular_transaction` (wewnątrzwspólnotowa transakcja trójstronna uproszczona → pole **P_23** w KSeF) w **`KSeF.md`**, w sekcji „Pola warunkowe".

## Kontekst

Pole wprowadzone w fakturownia PR [#14345](https://github.com/intum/fakturownia/pull/14345) („KSeF: transakcja trójstronna uproszczona"). Jest przyjmowane przez API przy tworzeniu faktur KSeF, ale nie było udokumentowane.

## Zawartość wpisu

- **Warunki uznania pola:** faktura PL, przychodowa, typu `vat` (lub korekta VAT), z `"reverse_charge": true`. Bez `reverse_charge` pole jest ignorowane (samo `triangular_transaction: true` nie włącza odwrotnego obciążenia).
- **Efekty automatyczne (nie trzeba przesyłać):** stawka `"np"` na pozycjach, `"np_tax_kind": "export_service"`, oznaczenie `"TT_D"` w `procedure_designations`.
- Przykład JSON + mapowanie na **P_23** w schemie FA (KSeF).

Umieszczone w `KSeF.md` (nie README) — pole jest specyficzne dla integracji KSeF.
